### PR TITLE
Installation instruction updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ vdb-config --proxy <your proxy URL> --proxy-disable no
 ```
 * Finally, install q2-fondue and refresh the QIIME 2 CLI cache:
 ```shell
-pip install git+https://github.com/bokulich-lab/q2-fondue.git
+pip install git+https://github.com/bokulich-lab/q2-fondue.git@5afa120cc8e017a1af6c1200a06326a2e08cc787
 
 qiime dev refresh-cache
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ q2-types
 q2cli
 q2templates
 qiime2
+scikit-bio<=0.5.6
 sourmash
 sra-tools>=2.11.0
 tqdm>=4.62.3


### PR DESCRIPTION
Following from https://github.com/bokulich-lab/q2-fondue/pull/140, this PR updates the environment set up instructions:
- q2-fondue installation is not switched to conda as the qiime2 version used here is 2021.11 and there seem to be some compatibility issues
- instead, the version is pinned to a specific commit to make sure the same version is installed every time
- `scikit-bio` is pinned to `v0.5.6` as its recent update breaks the environment